### PR TITLE
Add viewController property.

### DIFF
--- a/AQSInstagramActivity/Classes/AQSInstagramActivity.h
+++ b/AQSInstagramActivity/Classes/AQSInstagramActivity.h
@@ -9,5 +9,5 @@
 #import <UIKit/UIKit.h>
 
 @interface AQSInstagramActivity : UIActivity
-
+@property (nonatomic, strong) UIViewController *viewController;
 @end

--- a/AQSInstagramActivity/Classes/AQSInstagramActivity.m
+++ b/AQSInstagramActivity/Classes/AQSInstagramActivity.m
@@ -57,6 +57,9 @@ NSString *const kAQSInstagramURLScheme = @"instagram://app";
     self.controller = [self documentInteractionControllerForInstagramWithFileURL:URL withCaptionText:text];
     
     UIView *currentView = [self currentView];
+    if (self.viewController) {
+        currentView = self.viewController.view;
+    }
     [self.controller presentOpenInMenuFromRect:CGRectMake(0, 0, currentView.bounds.size.width, currentView.bounds.size.width) inView:currentView animated:YES];
 }
 


### PR DESCRIPTION
- This configures where the document controller is presented from.
- By default, the document controller is presented from the
  rootViewController's view

I was getting an error in the console about attempting to present the document controller from a view that wasn't part of the hierarchy, and nothing happened after selecting Instagram.  This was because I am using AQSInstagramActivity from a modal, and it tries to present from the root view controller's view which is not part of the modal's hierarchy.  With this fix, I was able to set the new `viewController` property to my modal and got it to work again.
